### PR TITLE
allow GnuPG to smoothly enter the passphrase

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -20,6 +20,7 @@ brew install trash
 brew install wget
 brew install the_silver_searcher
 brew install gpg
+brew install pinentry-mac
 
 # language management
 brew install asdf

--- a/gpg/gpg-agent.conf
+++ b/gpg/gpg-agent.conf
@@ -1,0 +1,1 @@
+pinentry-program /usr/local/bin/pinentry-mac

--- a/install_for_macos.sh
+++ b/install_for_macos.sh
@@ -23,3 +23,6 @@ ln -fs ${shell_path}/vim/.vimrc ~/
 
 # vscode
 ln -fs ${shell_path}/vscode/settings.json ~/Library/Application\ Support/Code/User/
+
+# gpg
+ln -fs ${shell_path}/gpg/gpg-agent.conf ~/.gnupg/


### PR DESCRIPTION
Install pinentry-mac to allow GnuPG to smoothly enter the passphrase when signing.